### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Prepare an environment for building the plugin on the **Fuel Master node**.
 
 1. Install the standard Linux development tools:
     ```
-    $ yum install createrepo rpm rpm-build dpkg-devel git
+    $  yum install createrepo dpkg-devel dpkg-dev rpm rpm-build
     ```
 
 2. Install the Fuel Plugin Builder. To do that, you should first get pip:


### PR DESCRIPTION
When running fpb --build . failed dependancy was reported:

[root@fuel fuel-plugin-scaleio]# fpb --build .
==================================================

Was not able to find required packages.

If you use Ubuntu, run:

    # sudo apt-get install createrepo rpm dpkg-dev

If you use CentOS, run:

    # yum install createrepo dpkg-devel dpkg-dev rpm rpm-build